### PR TITLE
Changing the example SCP command

### DIFF
--- a/source/data-management/managing-live-data.html.md
+++ b/source/data-management/managing-live-data.html.md
@@ -51,5 +51,5 @@ With a tunnel open, you could `scp` files on your local machine to your live sto
 nanobox tunnel data.storage -p 1234
 
 # In a different terminal
-scp -P 1235 -r uploads/* nanobox@127.0.0.1:/app/uploads/
+scp -P 1234 -r uploads/* nanobox@127.0.0.1:/app/uploads/
 ```


### PR DESCRIPTION
I would think that the port the SCP command uses should be the same as the port specified when creating the tunnel.