### PR TITLE
Fix some typos in the troubleshooting documentation

### DIFF
--- a/source/trbl/error/1000.html.md
+++ b/source/trbl/error/1000.html.md
@@ -16,7 +16,7 @@ Nanobox is unable to connect to your hosting provider.
 The full stack trace includes meta information related to the running sequence as well as the response from your service provider. These should help to pinpoint the exact cause of the error.
 
 ### Contact Your Hosting Provider
-There me be a known issue or outage preventing Nanobox from communicating your hosting provider. Your provider may be able to provide more information.
+There me be a known issue or outage preventing Nanobox from communicating with your hosting provider. Contact your hosting provider for more information.
 
 ### Retry the Process
 Once the issue with your provider has been resolved, retry the process. The retry button is available in your dashboard, to the right of the error information.

--- a/source/trbl/error/1001.html.md
+++ b/source/trbl/error/1001.html.md
@@ -5,11 +5,11 @@ ename: Provider Rejected
 ---
 
 ## The Issue
-Nanobox is unable to authenticate with your hosting provider. Any time we get a 403 Unauthorized error.
+Nanobox is unable to authenticate with your hosting provider any time it receives a 403 Unauthorized error.
 
 ### Possible Causes
 - Your provider auth credentials are invalid.
-- Your provider has placed a some type of restriction on your user account.
+- Your provider has placed some type of restriction on your user account.
 
 ## Steps to Take
 
@@ -20,9 +20,9 @@ The full stack trace includes meta information related to the running sequence a
 Make sure the authentication credentials your provided in your Nanobox dashboard match those required by your hosting provider (auth token, username, password, etc.).
 
 ### Contact Your Hosting Provider
-There me be a known issue or outage preventing Nanobox from authenticating correctly with your hosting provider. Your provider may be able to provide more information.
+There me be a known issue or outage preventing Nanobox from authenticating correctly with your hosting provider. Contact your hosting provider for more information.
 
 ### Retry the Process
-Once a new auth credentials are in place or an issue with your provider has been resolved, retry the process. The retry button is available in your dashboard, to the right of the error information.
+Once the new auth credentials are in place or the issue with your provider has been resolved, retry the process. The retry button is available in your dashboard, to the right of the error information.
 
 ![Retry Sequence](process-retry.png)

--- a/source/trbl/error/1004.html.md
+++ b/source/trbl/error/1004.html.md
@@ -16,9 +16,9 @@ There is an error within your app's private network on your hosting provider.
 The full stack trace includes meta information related to the running sequence as well as the response from attempts to connect to your service provider. These may help to pinpoint the exact cause of the error.
 
 ### Contact Your Hosting Provider
-There me be a known issue or outage preventing Nanobox from connecting with your hosting provider. Your provider may be able to provide more information.
+There me be a known issue or outage preventing Nanobox from connecting with your hosting provider. Contact your hosting provider for more information.
 
 ### Retry the Process
-Once a networking issue has been resolved, retry the process. The retry button is available in your dashboard, to the right of the error information.
+Once the networking issue has been resolved, retry the process. The retry button is available in your dashboard, to the right of the error information.
 
 ![Retry Sequence](process-retry.png)

--- a/source/trbl/error/1100.html.md
+++ b/source/trbl/error/1100.html.md
@@ -29,7 +29,7 @@ ping 123.45.67.89
 If the server is not accessible, you'll need to troubleshoot through your hosting provider.
 
 ### Contact Your Hosting Provider
-There me be a known issue or outage preventing Nanobox from connecting with your hosting provider. Your provider may be able to provide more information.
+There me be a known issue or outage preventing Nanobox from connecting with your hosting provider. Contact your hosting provider for more information.
 
 ### Retry the Process
 Once the issue has been resolved, retry the process. The retry button is available in your dashboard, to the right of the error information.

--- a/source/trbl/error/1101.html.md
+++ b/source/trbl/error/1101.html.md
@@ -14,7 +14,7 @@ Nanobox has ordered a host on your provider, but the status has never been set t
 ## Steps to Take
 
 ### Check with Your Hosting Provider
-Check your server's ordering status to ensure the process is still moving along. The time a takes to order and provision a new server depends on your provider. There may also be an issue that's holding the process up. Your provider should be able to provide more information.
+Check your server's ordering status to ensure the process is still moving along. The time it takes to order and provision a new server depends on your provider. There may also be an issue that's holding the process up. Contact your hosting provider for more information.
 
 ### Retry the Process
 Once the issue has been resolved, retry the process. The retry button is available in your dashboard, to the right of the error information.

--- a/source/trbl/error/1200.html.md
+++ b/source/trbl/error/1200.html.md
@@ -5,7 +5,7 @@ ename: Generic Provider Error
 ---
 
 ## The Issue
-Your provider returned an error as Nanobox tried to perform a task.
+Your provider returned an error when Nanobox tried to perform a task.
 
 ## Steps to Take
 

--- a/source/trbl/error/2003.html.md
+++ b/source/trbl/error/2003.html.md
@@ -8,10 +8,10 @@ ename: NanoAgent No Such Image
 The docker image specified in your boxfile.yml doesn't exist.
 
 ## Possible Causes
-- If the image path used in your boxfile.yml is wrong.
+- The image path used in your boxfile.yml is wrong.
 
 ## Steps to Take
-There are two possible solutions to this issue the require slightly different steps:
+There are two possible solutions to this issue that require slightly different steps:
 
 [Update the image path in your boxfile.yml](#update-the-image-path-in-your-boxfile-yml)  
 [Update the image path on Docker Hub](#update-the-image-path-on-docker-hub)  

--- a/source/trbl/error/3000.html.md
+++ b/source/trbl/error/3000.html.md
@@ -8,12 +8,12 @@ ename: Platform Error
 There is an error with one or more of the platform components running in your app.
 
 ## Possible Causes
-A platform service in your app has stopped running.
+A platform service in your app stopped running.
 
 ## Steps to Take
 
 ### Check Your Logs
-Your app's logs will provide any errors output from your app's platform components. These errors should point to the issue.
+Your app's logs will display any errors output from your app's platform components. These errors should point to the issue.
 
 ### Refresh the Component
 It's possible that the platform simply stopped running and needs to be refreshed. Instructions for refreshing components is provided in the [Server & Component Admin](/live-app-management/server-component-admin/#component-options) doc.

--- a/source/trbl/error/5101.html.md
+++ b/source/trbl/error/5101.html.md
@@ -17,20 +17,20 @@ LetsEncrypt requires that your domain be pointed to the server on which the cert
 ### Steps to Take
 
 #### Cancel the Sequence
-While Nanobox will continue to hit the LetsEncrypt API, there's a change the domain status will not change. The best thing to do is to cancel the process. To cancel a process, click the "Cancel" button in the upper-right corner of the process viewer.
+While Nanobox will continue to hit the LetsEncrypt API, there's a chance the domain status will not change. The best thing to do is to cancel the process. To cancel a process, click the "Cancel" button in the upper-right corner of the process viewer.
 
 ![Cancel a Process](process-cancel.png)
 
 #### Point Your Domain to Your App
-Make your domain is pointed to your app. For the provided app-name.gonano.io domains, this is done automatically, but if you're using your own custom domain, instructions are provided in the [Using Custom Domains](/domains-networking/custom-domains/) doc.
+Make sure your domain is pointed to your app. For the provided app-name.gonano.io domains, this is done automatically, but if you're using your own custom domain, instructions are provided in the [Using Custom Domains](/domains-networking/custom-domains/) doc.
 
-Keep in mind that changes to your domain do take time to propagate. To keep propagation times down, turn down your your domain's "Time to Live" (TTL) before updates.
+Keep in mind that changes to your domain do take time to propagate. To keep propagation times down, turn down your domain's "Time to Live" (TTL) before updates.
 
 #### Try it Again
 Once your domain is routing to your live app, try to create the LetsEncrypt bundle again and it should succeed.
 
 ## Invalid Domain
-LetsEncrypt doesn't recognize the domain you provided when created your SSL/TLS certificate as a valid domain.
+LetsEncrypt doesn't recognize the domain you provided when creating your SSL/TLS certificate as a valid domain.
 
 ### Steps to Take
 

--- a/source/trbl/error/5102.html.md
+++ b/source/trbl/error/5102.html.md
@@ -16,9 +16,9 @@ There was an error with the LetsEncrypt client
 The full stack trace includes meta information related to the running sequence as well as the LetsEncrypt client. These should help to pinpoint the exact cause of the error.
 
 ### Cancel the Sequence
-While Nanobox will continue to hit the LetsEncrypt API, there's a change the domain status will not change. The best thing to do is to cancel the process. To cancel a process, click the "Cancel" button in the upper-right corner of the process viewer.
+While Nanobox will continue to hit the LetsEncrypt API, there's a chance the domain status will not change. The best thing to do is to cancel the process. To cancel a process, click the "Cancel" button in the upper-right corner of the process viewer.
 
 ![Cancel a Process](process-cancel.png)
 
 ### Try it Again
-It may very have been just a one time fluke. There's a chance that if you try again it'll work, depending on the nature of the error.
+This could have been just a one time fluke. There's a chance that if you try again it'll work, depending on the nature of the error.

--- a/source/trbl/symlinks-in-win.html.md
+++ b/source/trbl/symlinks-in-win.html.md
@@ -5,7 +5,7 @@ description: If running in Windows, creating symlinks in an app running in Nanob
 keywords: symlinks in windows vm, symlinks in windows, windows symlinks not working
 ---
 
-Nanobox launches your app in a virtualized Linux environment and into which it mounts your local codebase. Creating symlinks in a codebase that mounted into a Linux environment, but actually resides in a Windows host filesystem can be tricky.
+Nanobox launches your app and mounts your local codebase in a virtualized Linux environment. Creating symlinks in a codebase that mounted into a Linux environment, but actually resides in a Windows host filesystem can be tricky.
 
 ## The Problem
 Windows and Linux/Unix have completely separate implementations for creating symlinks. Symlinks created in a Linux environment will not be honored by Windows and vice versa.


### PR DESCRIPTION
Fix some typos and rewrites a few sentences for more clarity in the troubleshooting documentation.