### PR TITLE
Added missing executables to remove for macOS

### DIFF
--- a/source/install/uninstall/_uninstall-mac.md
+++ b/source/install/uninstall/_uninstall-mac.md
@@ -13,7 +13,9 @@ Nanobox installs two executables on your system $PATH - `nanobox` and `nanobox-u
 #### Default Nanobox Executable Locations
 ```bash
 /usr/local/bin/nanobox
+/usr/local/bin/nanobox-machine
 /usr/local/bin/nanobox-update
+/usr/local/bin/nanobox-vpn
 ```
 
 If the Nanobox executables are installed at a non-default location, you can use the following commands to find where they are installed.
@@ -21,7 +23,9 @@ If the Nanobox executables are installed at a non-default location, you can use 
 #### Finding the Location of Nanobox Executables
 ```bash
 which nanobox
+which nanobox-machine
 which nanobox-update
+which nanobox-vpn
 ```
 
 Once you know where the Nanobox executables are located, you can use the following commands to remove them.
@@ -29,7 +33,9 @@ Once you know where the Nanobox executables are located, you can use the followi
 #### Removing Nanobox Executables
 ```bash
 rm -f /path/to/nanobox
+rm -f /path/to/nanobox-machine
 rm -f /path/to/nanobox-update
+rm -f /path/to/nanobox-vpn
 ```
 
 ### Uninstall Virtual Box


### PR DESCRIPTION
There are more nanobox commands to remove from the system than what the current installation guide list.

This merge request adds the two missing.
